### PR TITLE
Use a WeakSet to track known-removed nodes

### DIFF
--- a/esm/upgrade.js
+++ b/esm/upgrade.js
@@ -33,7 +33,7 @@ export default (document, {MutationObserver, Element}) => {
   };
 
   const parseRecords = records => {
-    const added = new Set, removed = new Set;
+    const added = new Set, removed = new WeakSet;
     for (const {addedNodes, removedNodes} of records) {
       loop(removedNodes, added, removed, false, false);
       loop(addedNodes, added, removed, true, false);


### PR DESCRIPTION
Hi! Just happened to be reading through the code (very cool project!) and saw this. Feel free to close if it's not valid.

I was thinking after a node gets removed from the document, it might get garbage collected -- then it won't be possible to get added again and it's not necessary to track anymore in `removed`.

Presumably as long as the custom element and the document are live, the `added` nodes will also be live, so this other set doesn't need to contain weak references.